### PR TITLE
fix(deploy): use bare domain in CNAME

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-https://serdyuchenko.com
+serdyuchenko.com


### PR DESCRIPTION
## Summary

`public/CNAME` contained a full URL (`https://serdyuchenko.com`) instead of a bare host. GitHub Pages expects only the hostname in `CNAME`. Since the deploy runs through GitHub Actions and this file sets the custom domain from the artifact, the protocol prefix could break custom-domain binding on each deploy.

Fixes #127.

## Changes

- `public/CNAME`: `https://serdyuchenko.com` → `serdyuchenko.com` (also added trailing newline)

## Checklist
- [ ] `npm run build`
- [ ] Links checked (if applicable)
- [ ] Screenshots attached (optional)

## Screenshots (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)