### PR TITLE
chore(security): security headers strategy for serdyuchenko.com (CSP + Referrer-Policy via meta)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,4 +7,12 @@ export default defineConfig({
     '/cv': '/',
   },
   integrations: [sitemap()],
+  vite: {
+    build: {
+      // Emit component <script> as an external same-origin module instead of
+      // inlining it, so the CSP in BaseLayout.astro can stay `script-src 'self'`
+      // without `'unsafe-inline'`. See docs/decisions.md (security headers).
+      assetsInlineLimit: 0,
+    },
+  },
 });

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,5 +1,69 @@
 # Decisions
 
+## 2026-06-13 — Security headers strategy
+
+**Decision:** Stay on **GitHub Pages**. Apply the hardening that is achievable in
+static HTML now (CSP + Referrer-Policy via `<meta>`), keep the codebase
+CSP-clean, and document the remaining gap rather than introducing a proxy/Worker
+just to set HTTP response headers.
+
+**Context:** `https://serdyuchenko.com/` is served by GitHub Pages, which cannot
+emit custom response headers. A `curl -I` on 2026-06-13 confirmed none of
+`Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy`,
+`X-Content-Type-Options` or `Strict-Transport-Security` are present. The site is
+a static, zero-script personal CV: production HTML loads no external scripts,
+fonts or analytics; all images are same-origin; external URLs are anchor links
+only. Risk is low, so a hosting migration is disproportionate to the benefit.
+
+**What ships now (in `src/layouts/BaseLayout.astro`):**
+
+- `Content-Security-Policy` via `<meta http-equiv>`:
+
+  ```
+  default-src 'self'; base-uri 'self'; form-action 'self'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'
+  ```
+
+  - `style-src 'unsafe-inline'` is required: Astro emits one scoped inline
+    `<style>` block per page in the production build (verified in `dist/`).
+  - `script-src 'self'` is enough because the only interactivity (the CV print
+    button) was moved out of an inline `onclick` into a `<script>` in
+    `src/components/cv/CvIntro.astro`. `astro.config.mjs` sets
+    `vite.build.assetsInlineLimit: 0` so Astro emits that script as an external
+    same-origin module rather than inlining it — keeping `script-src` free of
+    `'unsafe-inline'`. Do not remove that setting without also relaxing the CSP.
+  - `frame-ancestors` is intentionally omitted: it is ignored in a `<meta>` CSP
+    and only works as a real header.
+
+- `Referrer-Policy` via `<meta name="referrer" content="strict-origin-when-cross-origin">`.
+
+**Known limitation (cannot be delivered by GitHub Pages / `<meta>`):**
+`X-Content-Type-Options`, `Permissions-Policy`, `Strict-Transport-Security` and
+the header-only `frame-ancestors` directive require a host that can set response
+headers. As an interim win, enable **Settings → Pages → Enforce HTTPS** so the
+GitHub edge serves HSTS for the custom domain.
+
+**Future migration path:** if the site moves behind a headers-capable layer
+(e.g. Cloudflare Pages/Worker), drop the following into `public/_headers`
+(Cloudflare Pages format) — it is the full target set and supersedes the `<meta>`
+tags, which can then be removed:
+
+```
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+Revisit this decision if the site gains comments, third-party scripts or
+interactive widgets — at that point a headers-capable host (and tighter
+`script-src`/`img-src`) becomes worthwhile.
+
+**Verify after deploy:** `curl -I https://serdyuchenko.com/` (CSP/Referrer-Policy
+now come through the HTML, so also confirm via the page source / browser
+DevTools) or re-run securityheaders.com.
+
 ## 2026-01-14 — URL strategy
 
 **Decision:** Keep using the custom domain `serdyuchenko.com` as the canonical site URL (not the default `anton415.github.io` URL).

--- a/src/components/cv/CvIntro.astro
+++ b/src/components/cv/CvIntro.astro
@@ -10,12 +10,20 @@ const { summary } = cv;
   <h1>{profile.name}</h1>
   <p class="lede">{profile.headline} — {profile.location}</p>
   <div class="cv-actions screen-only">
-    <button type="button" class="cv-action cv-action-primary" onclick="window.print()">Печать / PDF</button>
+    <button type="button" class="cv-action cv-action-primary" data-print-button>Печать / PDF</button>
   </div>
   <ul class="summary-list">
     {summary.map((item) => <li>{item}</li>)}
   </ul>
 </section>
+
+<script>
+  // Bundled by Astro into a same-origin module, so it stays within a
+  // `script-src 'self'` CSP (no inline handler / 'unsafe-inline' needed).
+  document
+    .querySelector('[data-print-button]')
+    ?.addEventListener('click', () => window.print());
+</script>
 
 <style>
   .hero h1 {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,6 +21,16 @@ const twitterCard = resolvedImage ? 'summary_large_image' : 'summary';
 <html lang="ru">
   <head>
     <meta charset="utf-8" />
+    {/* Security hardening deliverable via static HTML on GitHub Pages (no custom
+        response headers). Keep these first so the CSP governs all later content.
+        Header-only directives (frame-ancestors), X-Content-Type-Options,
+        Permissions-Policy and HSTS are documented in docs/decisions.md for a
+        future headers-capable host. */}
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; form-action 'self'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <title>{metaTitle}</title>


### PR DESCRIPTION
## Summary

Resolves the security-headers gap from #136. GitHub Pages serves `serdyuchenko.com` with **no** hardening headers and cannot set custom response headers. Rather than stand up a proxy/Worker for a zero-JS personal CV site (disproportionate; risk is low per the issue), this ships the hardening achievable in static HTML now, makes the codebase CSP-clean, and documents the rest.

**Decision: stay on GitHub Pages** — see the ADR in `docs/decisions.md` (2026-06-13 — Security headers strategy).

## Changes

- **`src/layouts/BaseLayout.astro`** — add `Content-Security-Policy` and `Referrer-Policy` via `<meta>`, placed first in `<head>` so the CSP governs all later content.
  - CSP: `default-src 'self'; base-uri 'self'; form-action 'self'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'`
  - `style-src 'unsafe-inline'` is required because Astro emits scoped inline `<style>` blocks in the production build (verified in `dist/`).
  - `frame-ancestors` is intentionally omitted — it is ignored in a `<meta>` CSP and only works as a real header.
- **`src/components/cv/CvIntro.astro`** — replace the inline `onclick="window.print()"` with a `<script>` click listener, so `script-src` can stay `'self'` without `'unsafe-inline'`.
- **`astro.config.mjs`** — set `vite.build.assetsInlineLimit: 0` so the component script is emitted as an external same-origin module instead of being inlined (Astro inlines small scripts by default, which `script-src 'self'` would otherwise block).
- **`docs/decisions.md`** — ADR documenting the GitHub Pages limitation, what ships now, the header-only directives that still require a headers-capable host (`X-Content-Type-Options`, `Permissions-Policy`, `Strict-Transport-Security`, header `frame-ancestors`), and a copy-paste-ready full `_headers` set for a future migration.

## Issue checklist (#136)

- [x] Strategy decided & documented (stay on GitHub Pages + ADR).
- [x] Inline `onclick` handler removed from `CvIntro.astro`.
- [x] Verified Astro inline `<style>` behavior in production → CSP uses `style-src 'self' 'unsafe-inline'`.
- [x] Minimal header set defined (meta now; full header set documented for later).
- [ ] Re-check `curl -I https://serdyuchenko.com/` / securityheaders.com **after deploy** (CSP + Referrer-Policy come through the HTML; the other three need a headers-capable host). Also enable **Settings → Pages → Enforce HTTPS** for HSTS at the edge.

## Verification

- `npm run build`, `npm run lint`, `npm run format:check` all pass.
- Production HTML: zero inline event handlers, zero inline-code scripts; print logic is an external same-origin `/_astro/*.js` module.
- Browser preview of the built site: **zero CSP violations** on `/` and `/links/`, and the print button still triggers `window.print()`.

## Checklist

- [x] `npm run build`
- [x] Links checked (if applicable)
- [ ] Screenshots attached (optional)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)